### PR TITLE
setup.cfg: fix invalid version spec

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ packages = find:
 include_package_data = true
 zip_safe = false
 
-python_requires = >=3.6.*
+python_requires = >=3.6
 
 install_requires =
     attrs >= 18.1, !=20.1.0


### PR DESCRIPTION
after PEP440 support has been removed in newer setuptools (v66+) this would otherwise result in an error like setuptools.extern.packaging.specifiers.InvalidSpecifier: Invalid specifier: '>=3.6.*'

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>