### PR TITLE
Usage of dash-separated 'console-scripts' is deprecated

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,5 +100,5 @@ docs =
     doc8>=0.11.2
 
 [options.entry_points]
-console-scripts =
+console_scripts =
     extractcode = extractcode.cli:extractcode


### PR DESCRIPTION
Use the underscore name 'console_scripts' instead. By 2023-Sep-26, you need to update your project and remove deprecated calls or your builds will no longer be supported.